### PR TITLE
reverting part of a fix

### DIFF
--- a/vocab.json
+++ b/vocab.json
@@ -637,7 +637,7 @@
                 "english": ["in the countryside", "in the country"]},
                 {"id": 4,
                 "spanish": ["en un pueblo"],
-                "english": ["in a town", "in a village"]},
+                "english": ["in a town/village", "in a town", "in a village"]},
                 {"id": 5,
                 "spanish": ["en la ciudad"],
                 "english": ["in the city"]},


### PR DESCRIPTION
Over-corrected - this re-adds the original wording as well as the separated versions.